### PR TITLE
New tool: palletjack2ansible

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,6 +193,7 @@ Style/ColonMethodCall:
 # Cop supports --auto-correct.
 Layout/CommentIndentation:
   Exclude:
+    - 'tools/spec/palletjack2ansible_spec.rb'
     - 'tools/spec/palletjack2salt_spec.rb'
 
 # Offense count: 1
@@ -290,6 +291,7 @@ Style/GlobalVars:
     - 'spec/palletjack-tool_spec.rb'
     - 'spec/palletjack_spec.rb'
     - 'spec/spec_helper.rb'
+    - 'tools/spec/palletjack2ansible_spec.rb'
     - 'tools/spec/palletjack2kea_spec.rb'
     - 'tools/spec/palletjack2salt_spec.rb'
     - 'tools/spec/palletjack2unbound_spec.rb'
@@ -331,6 +333,7 @@ Layout/AssignmentIndentation:
     - 'lib/palletjack/tool.rb'
     - 'tools/exe/*'
     - 'tools/lib/palletjack2zones.rb'
+    - 'tools/spec/palletjack2ansible_spec.rb'
     - 'tools/spec/palletjack2kea_spec.rb'
     - 'tools/spec/palletjack2salt_spec.rb'
 
@@ -375,6 +378,7 @@ Layout/MultilineMethodCallBraceLayout:
   Exclude:
     - 'tools/exe/dump_pallet'
     - 'tools/exe/palletjack2kea'
+    - 'tools/spec/palletjack2ansible_spec.rb'
     - 'tools/spec/palletjack2kea_spec.rb'
     - 'tools/spec/palletjack2salt_spec.rb'
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 Development
 
+  Tool changes:
+
+    * New tool palletjack2ansible, for writing Ansible inventories and
+      variable files
+
   Packaging changes:
 
     * Fixed incompatibility with Ruby 2.7

--- a/examples/warehouse/_config/PalletJack2Ansible/README
+++ b/examples/warehouse/_config/PalletJack2Ansible/README
@@ -1,0 +1,41 @@
+PalletJack2Ansible Configuration
+================================
+
+Keys under `variables.global.*` are used to store information about
+which kinds of pallets to copy into global Ansible variables under the
+name space `palletjack:global`.
+
+  - For pallet kinds listed under `.each-pallet`, the entire hierarchy
+    of pallets is copied.
+
+  - For pallet kinds listed under `.each-leaf-pallet`, only leaves in
+    the hierarchy are copied, i.e. pallets without children of their
+    own kind.
+
+Keys under `variables.per-host.each-subtree` are used to store
+information about which key subtrees to copy from each `system` object
+into Ansible host variables under the name space `palletjack`.
+
+Files:
+
+  _config/PalletJack2Ansible/global.yaml
+  _config/PalletJack2Ansible/per-minion.yaml
+
+
+YAML:
+
+global.yaml:
+  variables:
+    global:
+      each-pallet:
+        <dst key>: <pallet kind>  # Copy pallets to global variables.
+      each-leaf-pallet:
+        <dst key>: <pallet kind>  # Copy leaf pallets to global
+                                  # variables.
+
+per-host.yaml
+  variables:
+    per-host:
+      each-subtree:
+        <dst key>: <src keypath>  # Copy key subtrees to host
+                                  # variables.

--- a/examples/warehouse/_config/PalletJack2Ansible/global.yaml
+++ b/examples/warehouse/_config/PalletJack2Ansible/global.yaml
@@ -1,0 +1,7 @@
+---
+variables:
+  global:
+    each-pallet:
+      os: os
+    each-leaf-pallet:
+      netinstall: netinstall

--- a/examples/warehouse/_config/PalletJack2Ansible/per-host.yaml
+++ b/examples/warehouse/_config/PalletJack2Ansible/per-host.yaml
@@ -1,0 +1,6 @@
+---
+variables:
+  per-host:
+    each-subtree:
+      system: system
+      service: net.service

--- a/tools/exe/palletjack2ansible
+++ b/tools/exe/palletjack2ansible
@@ -1,0 +1,140 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Write YAML files containing Ansible inventory data.
+#
+# Intended to be run from a Git post-update hook or similar, since
+# running the entire Pallet Jack infrastructure for every Ansible
+# invocation is a bit excessive, writing Ansible inventory and
+# variable files in YAML format.
+
+require 'palletjack/tool'
+require 'yaml'
+
+class PalletJack2Ansible < PalletJack::Tool
+  def parse_options(opts)
+    # rubocop:disable Layout/FirstArgumentIndentation
+    opts.banner =
+"Usage: #{$PROGRAM_NAME} -w <warehouse> [ -d <dir> ]
+
+Write Ansible inventory data from a Palletjack warehouse.
+
+The inventory will be written to $dir/inventory.yaml, with
+global variables written to $dir/group_vars/all and host variables
+to $dir/host_vars/$hostname."
+    # rubocop:enable Layout/FirstArgumentIndentation
+
+    opts.on('-d DIR', '--directory DIR', 'Ansible inventory directory',
+            String) { |dir| options[:dir] = dir }
+
+    required_option :dir
+  end
+
+  # Helpers for generating inventory
+
+  def process_inventory
+    inventory = { 'all' => { 'hosts' => {} } }
+    jack.each(kind: 'system') do |system|
+      inventory['all']['hosts'][system['net.dns.fqdn']] = nil
+    end
+    inventory
+  end
+
+  # Helpers for generating global variables
+
+  def process_global_variables
+    result = {}
+
+    config['variables.global.each-pallet']&.each do |dst_key, kind|
+      result[dst_key] ||= {}
+
+      jack.each(kind: kind) do |pallet|
+        result[dst_key][pallet.full_name] = pallet.to_hash.except('pallet')
+      end
+    end
+
+    config['variables.global.each-leaf-pallet']&.each do |dst_key, kind|
+      result[dst_key] ||= {}
+
+      jack.each(kind: kind) do |pallet|
+        next unless pallet.children(kind: kind).empty?
+
+        result[dst_key][pallet.full_name] = pallet.to_hash.except('pallet')
+      end
+    end
+
+    result
+  end
+
+  # Helpers for generating host variables
+
+  def ipv4_interfaces(system)
+    result = {}
+
+    system.children(kind: 'ipv4_interface') do |interface|
+      result[interface['net.layer2.name']] = {
+        interface['net.ipv4.address'] =>
+        interface.filter('net.ipv4', 'net.layer2').to_hash
+      }
+    end
+
+    result
+  end
+
+  def process_host_variables
+    result = {}
+
+    jack.each(kind: 'system') do |system|
+      yaml_output = {}
+      yaml_output['ipv4_interfaces'] = ipv4_interfaces(system)
+
+      config['variables.per-host.each-subtree'].each do |dst_key, src_key|
+        yaml_output[dst_key] = system.fetch(src_key)
+      end
+
+      result[system['net.dns.fqdn']] = { 'palletjack' => yaml_output }
+    end
+
+    result
+  end
+
+  # The internal representation of the generated configuration, ready
+  # to be tested or printed.
+
+  attr_reader :ansible_config
+
+  def process
+    @ansible_config = {}
+
+    @ansible_config[:inventory] = process_inventory
+    @ansible_config[:global] = process_global_variables
+    @ansible_config[:hosts] = process_host_variables
+  end
+
+  def output
+    config_dir :dir
+    config_file :dir, 'inventory.yaml' do |inventory_file|
+      inventory_file << @ansible_config[:inventory].to_yaml
+    end
+
+    config_dir :dir, 'group_vars'
+    config_file :dir, 'group_vars', 'all' do |varfile|
+      varfile << git_header('palletjack2ansible')
+      varfile <<
+        { 'palletjack' => { 'global' => @ansible_config[:global] } }.to_yaml
+    end
+
+    config_dir :dir, 'host_vars'
+
+    @ansible_config[:hosts].each do |id, config|
+      config_file :dir, 'host_vars', "#{id}.yaml" do |yamlfile|
+        yamlfile << git_header('palletjack2ansible')
+        yamlfile << config.to_yaml
+      end
+    end
+  end
+end
+
+if PalletJack2Ansible.standalone?(__FILE__)
+  PalletJack2Ansible.run
+end

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -56,7 +56,7 @@ Write configuration for the Kea DHCP server from a Palletjack warehouse"
       end
 
       if net['net.dns.resolver']
-        resolvers = ''
+        resolvers = String.new
         net['net.dns.resolver'].each do |resolver|
           resolvers << resolver << ', '
         end

--- a/tools/palletjack-tools.gemspec
+++ b/tools/palletjack-tools.gemspec
@@ -38,6 +38,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.1.2'
   spec.add_development_dependency 'rspec_structure_matcher', '~> 0.0.6'
-
-  spec.has_rdoc	= true
 end

--- a/tools/spec/palletjack2ansible_spec.rb
+++ b/tools/spec/palletjack2ansible_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+load 'palletjack2ansible'
+
+describe 'palletjack2ansible' do
+  context 'generated host inventory' do
+    before :each do
+      @tool = PalletJack2Ansible.instance
+      allow(@tool).to receive(:argv).and_return(
+        ['-w', $EXAMPLE_WAREHOUSE,
+         '-d', Dir.tmpdir]) # Won't actually be written to, but needs
+                            # to exist to make the command line option
+                            # parser happy
+      @tool.setup
+      @tool.process
+      @inventory = @tool.ansible_config[:inventory]
+    end
+
+    it 'contains the global group' do
+      all_hosts = { 'all' => { 'hosts' => Hash } }
+      expect(@inventory).to have_structure all_hosts
+    end
+
+    it 'contains all hosts in the warehouse' do
+      @tool.jack.each(kind: 'system') do |system|
+        expect(@inventory['all']['hosts']).to include system['net.dns.fqdn']
+      end
+    end
+
+    it 'has no configuration embedded in the inventory' do
+      expect(@inventory['all']['hosts'].values).to all(be_nil)
+    end
+  end
+
+  context 'generated global configuration' do
+    before :each do
+      @tool = PalletJack2Ansible.instance
+      allow(@tool).to receive(:argv).and_return(
+        ['-w', $EXAMPLE_WAREHOUSE,
+         '-d', Dir.tmpdir]) # Won't actually be written to, but needs
+                            # to exist to make the command line option
+                            # parser happy
+      @tool.setup
+      @tool.process
+      @global = @tool.ansible_config[:global]
+    end
+
+    it 'contains configuration for os images' do
+      os_vars = { 'host' => { 'netinstall' => Hash,
+                              'pxelinux' => Hash },
+                  'system' => Hash }
+      @tool.jack.each(kind: 'os') do |os|
+        expect(@global['os'][os.full_name]).to have_structure(os_vars)
+      end
+    end
+
+    it 'contains configuration for netinstall configurations' do
+      ni_vars = { 'host' => { 'netinstall' => Hash,
+                              'pxelinux' => Hash },
+                  'system' => Hash }
+      @tool.jack.each(kind: 'netinstall') do |ni|
+        next unless ni.children(kind: 'netinstall').empty?
+
+        expect(@global['netinstall'][ni.full_name]).to have_structure(ni_vars)
+      end
+    end
+  end
+
+  context 'generated host variables' do
+    before :each do
+      @tool = PalletJack2Ansible.instance
+      allow(@tool).to receive(:argv).and_return(
+        ['-w', $EXAMPLE_WAREHOUSE,
+         '-d', Dir.tmpdir]) # Won't actually be written to, but needs
+                            # to exist to make the command line option
+                            # parser happy
+      @tool.setup
+      @tool.process
+      @hosts = @tool.ansible_config[:hosts]
+    end
+
+    it 'contains configuration for some known clients' do
+      basic_structure = { 'palletjack' => Hash }
+      expect(@hosts['vmhost1.example.com']).to have_structure(basic_structure)
+      expect(@hosts['testvm.example.com']).to have_structure(basic_structure)
+    end
+
+    it 'contains configuration for all clients in the warehouse' do
+      hosts = {}
+      @tool.jack.each(kind: 'system') do |system|
+        hosts[system['net.dns.fqdn']] = { 'palletjack' => Hash }
+      end
+      expect(@hosts).to have_structure(hosts)
+    end
+
+    it 'contains network configuration' do
+      interfaces =
+      {
+        'em1' =>
+        {
+          '192.168.0.1' =>
+          {
+            'net' =>
+            {
+              'ipv4' =>
+              {
+                'gateway' => '192.168.0.1',
+                'prefixlen' => '24',
+                'cidr' => '192.168.0.0/24',
+                'address' => '192.168.0.1'
+              },
+              'layer2' =>
+              {
+                'address' => '14:18:77:ab:cd:ef',
+                'name' => 'em1'
+              }
+            }
+          }
+        }
+      }
+      expect(@hosts['vmhost1.example.com']['palletjack']['ipv4_interfaces']).to have_structure(interfaces)
+    end
+
+    it 'contains system configuration' do
+      system =
+      {
+        'os' => 'CentOS-7.4.1708-x86_64',
+        'architecture' => 'x86_64',
+        'role' => ['kvm-server', 'ssh-server'],
+        'name' => 'vmhost1'
+      }
+      expect(@hosts['vmhost1.example.com']['palletjack']['system']).to have_structure(system)
+    end
+
+    context 'contains service configuration' do
+      it 'for syslog' do
+        syslog_config =
+        [
+          {
+            'address' => 'syslog-archive.example.com',
+            'port' => '514',
+            'protocol' => 'udp'
+          },
+          {
+            'address' => 'logstash.example.com',
+            'port' => '5514',
+            'protocol' => 'tcp'
+          }
+        ]
+        0.upto(syslog_config.length) do |i|
+          expect(@hosts['vmhost1.example.com']['palletjack']['service']['syslog'][i]).to have_structure(syslog_config[i])
+        end
+      end
+
+      it 'for zabbix' do
+        zabbix_config =
+        [
+          { 'address' => 'zabbix.example.com' },
+          {
+            'address' => 'zabbix2',
+            'port' => '10051'
+          }
+        ]
+        0.upto(zabbix_config.length) do |i|
+          expect(@hosts['vmhost1.example.com']['palletjack']['service']['zabbix'][i]).to have_structure(zabbix_config[i])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to be able to use Ansible with Pallet Jack, we need to export the Pallet Jack data to Ansible. Writing an inventory plugin would be possible, but just like for Salt we don't want to have to run the entire Pallet Jack machinery for every invocation of our configuration management tool. Hence, this tool that exports the host list, global variables, and host-specific variables to YAML files ready to be picked up by Ansible.